### PR TITLE
Added objective function Bound value for MIP.

### DIFF
--- a/src/Sonnet/Extensions.cs
+++ b/src/Sonnet/Extensions.cs
@@ -330,5 +330,30 @@ namespace Sonnet
             return Expression.ScalarProduct(coefs, variables);
         }
 
+        /// <summary>
+        /// Gets the current bound for MIP.
+        /// If the current solution is Optimal, then Bound equals objective Value.
+        /// If not yet optimal, then Bound is best relaxation bound of all nodes left on the search tree.
+        /// This value is not available for all solvers.
+        /// </summary>
+        /// <param name="solver">The solver. Only available for OsiCbc.</param>
+        /// <returns>The current bound</returns>
+        internal static double Bound(this COIN.OsiSolverInterface solver)
+        {
+            Ensure.NotNull(solver, "solver");
+
+            if (solver.isProvenOptimal())
+            {
+                return solver.getObjValue();
+            }
+
+            // not optimal, so depends per solver
+            if (solver is COIN.OsiCbcSolverInterface osiCbc)
+            {
+                return osiCbc.Model.getBestPossibleObjValue();
+            }
+
+            throw new NotImplementedException($"Bound is not implemented for OsiSolverInterface type {solver.GetType()}");
+        }
     }
 }

--- a/src/Sonnet/Objective.cs
+++ b/src/Sonnet/Objective.cs
@@ -160,7 +160,7 @@ namespace Sonnet
         }
 
         /// <summary>
-        /// Gets the level of this objective. This should be equal to the Value.
+        /// Calculates the level of this objective, i.e. fill in the values of the variable in expression of this objective. This should be equal to the Value.
         /// See Level of the Expression class.
         /// </summary>
         /// <returns>The level.</returns>
@@ -168,6 +168,18 @@ namespace Sonnet
         {
             Ensure.IsTrue(Assigned, "No solver not set!");
             return expression.Level();
+        }
+
+        /// <summary>
+        /// Gets the current Bound of this objective for MIP.
+        /// If the current solution is Optimal, then Objective Bound equals Objective Value.
+        /// If not yet optimal, then Bound is best relaxation bound of all nodes left on the search tree.
+        /// This value is set (AssignSolution) after the optimisation.
+        /// This value is not available for all solvers.
+        /// </summary>
+        public double Bound 
+        { 
+            get { return bound; } 
         }
 
         /// <summary>
@@ -203,14 +215,16 @@ namespace Sonnet
         }
         
         /// <summary>
-        /// Assigns the given solver, and set the Value of this objective.
+        /// Assigns the given solver, and set the Value and Bound of this objective.
         /// </summary>
         /// <param name="solver">The solver to be assigned.</param>
         /// <param name="value">The new Value of this objective.</param>
-        internal void Assign(Solver solver, double value)
+        /// <param name="bound"">The new Bound of this objective.</param>
+        internal void Assign(Solver solver, double value, double bound)
         {
             base.Assign(solver, -1);
             this.value = value;
+            this.bound = bound;
         }
 
         /// <summary>
@@ -273,5 +287,6 @@ namespace Sonnet
         private static int numberOfObjectives = 0;
         private Expression expression;
         private double value;
+        private double bound;
     }
 }

--- a/src/Sonnet/Solver.cs
+++ b/src/Sonnet/Solver.cs
@@ -711,8 +711,8 @@ namespace Sonnet
             // these changes have to be passed on to all registered models.
             obj.Assemble();
             obj.Register(this);
-            obj.Assign(this, 0.0); // immediately also STORE!
-
+            obj.Assign(this, 0.0, double.NaN); // immediately also STORE!
+       
             GenerateVariables(obj.Coefficients);
 
             GenerateVariables(obj.QuadCoefficients);
@@ -1796,8 +1796,8 @@ namespace Sonnet
                     }
                 }
             } // unsafe
-
-            objective.Assign(this, solver.getObjValue() + objective.Constant);
+            
+            objective.Assign(this, solver.getObjValue() + objective.Constant, IsMIP?(solver.Bound() + objective.Constant): double.NaN);
 
             if (IsProvenOptimal)
             {

--- a/test/SonnetTest/Sonnet_CbcTests.cs
+++ b/test/SonnetTest/Sonnet_CbcTests.cs
@@ -97,6 +97,9 @@ namespace SonnetTest
             SonnetLog.Default.Error("Log Error");
 
             Model model = Model.New("mas74.mps");
+            Expression obj = (Expression)model.Objective;
+            obj.Add(10000.0); // check that the objective constant is taken into account.
+            model.Objective = obj;
 
             Solver solver = new Solver(model, typeof(OsiCbcSolverInterface));
             OsiCbcSolverInterface osiCbc = solver.OsiSolver as OsiCbcSolverInterface;
@@ -105,10 +108,17 @@ namespace SonnetTest
 
             Assert.IsTrue(solver.IsFeasible(), "with solution and hence feasible");
             Assert.IsFalse(solver.IsProvenOptimal, "should not be optimal yet (unless solver got a lot better)");
+            Assert.IsTrue(model.Objective.Bound < model.Objective.Value, "Bound must be less than current solution.");
 
-            // Allow also better solutions, but not worse. The problem is minimization.
-            // If you machine is significantly slower, the solution will be worse and this test will fail--but can be ignored.
-            Assert.IsTrue(model.Objective.Value >= 11801.18 && model.Objective.Value <= 12465, $"Best minimization solution of mas74 until now is ${model.Objective.Value} but should be between 11801.18 (opt) and 12465");
+            // The problem is minimization.
+            // Allow also better solutions, but not worse. 
+            // If your machine is significantly slower, the solution value will be worse (higher) and this test will fail--but can be ignored.
+            Assert.IsTrue(model.Objective.Value >= 21801.18 && model.Objective.Value <= 22465, $"Best minimization solution of mas74 until now is ${model.Objective.Value} but should be between 21801.18 (opt) and 22465");
+            
+            // bound is expected to be 20482 on the reference machine.
+            // If your machine is slower, the bound will be worse (lower)
+            // If your machine is faster, the bound could be better (higher)
+            Assert.IsTrue(model.Objective.Bound >= 20300.0 && model.Objective.Bound <= 20700.0, $"Bound (Gap) is now ${model.Objective.Bound} but should be betweeen 20300 and 20700");
         }
 
         private static int SonnetCbcTest5numSolutions = 0;

--- a/test/SonnetTest/Sonnet_StressTests.cs
+++ b/test/SonnetTest/Sonnet_StressTests.cs
@@ -127,13 +127,15 @@ namespace SonnetTest
 
                     string rowName = "MyConstraint(" + m + ")";
                     RangeConstraint con = (RangeConstraint)model.Add(rowName,
-                        -model.Infinity <= expr <= available);
-
+                        -model.Infinity <= expr <= 0.5*Z);
                     expr.Assemble();
                     Assert.IsTrue(expr.NumberOfCoefficients == Z + 1);
 
                     expr.Clear();
                 }
+
+                model.Objective = vars.Sum();
+                model.ObjectiveSense = ObjectiveSense.Maximise;
 
                 Console.WriteLine(string.Format("Thread {0}: Start Generate... (this can take a while)", threadid));
 


### PR DESCRIPTION
Currently only implemented for OsiCbc, available via objective.Bound() and osiSolverInterface.Bound() where applicable.