### PR TITLE
Minor VS updates and appveyor fix 

### DIFF
--- a/CHANGELOG.txt
+++ b/CHANGELOG.txt
@@ -9,6 +9,15 @@ The File Version numbers change with every release. In contrast, the Assembly Ve
  - MIQP. Quadratic objective for MIP. Quadratic objective works with OsiClp (QP). 
    Quadratic objectives via OsiCbc does not work well and is disabled. (Unconfirmed for Cbc 2.10.10)
 
+[1.4.0] Dec 2023
+Minor release of Sonnet, using Cbc 2.10.11.
+Sonnet stable 1.4 brings the latest changes from sonnet master back to Sonnet 1.3 based on Cbc 2.10.11, 
+including nested source folders (Cbc\Cbc etc.)
+Thus, Sonnet 1.4 starts from master and downgrades where necessary.
+TODO before release: 
+- investigate batch build fails, but manual builds work
+- fix Sonnet_quadraticTests
+
 [1.3.1.0] June 2023
 Patch release of Sonnet, upgrading to Cbc 2.10.10 and support .NET 6.0 and .NET Framework 4.8.
  - Bump to Cbc 2.10.10

--- a/MSVisualStudio/v17/Sonnet.sln
+++ b/MSVisualStudio/v17/Sonnet.sln
@@ -12,6 +12,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 		..\..\get-dependencies.bat = ..\..\get-dependencies.bat
 		..\..\LICENSE.txt = ..\..\LICENSE.txt
 		..\..\NOTICE.txt = ..\..\NOTICE.txt
+		..\..\.coin-or\projDesc.xml = ..\..\.coin-or\projDesc.xml
 		..\..\README.md = ..\..\README.md
 		..\..\THIRD-PARTY-LICENSE.txt = ..\..\THIRD-PARTY-LICENSE.txt
 	EndProjectSection

--- a/MSVisualStudio/v17/SonnetWrapperTest/SonnetWrapperTest.vcxproj
+++ b/MSVisualStudio/v17/SonnetWrapperTest/SonnetWrapperTest.vcxproj
@@ -95,7 +95,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\..\..\..\BuildTools\headers;..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
       <RuntimeLibrary />
     </ClCompile>
     <Link>
@@ -110,7 +110,7 @@
       <Optimization>Disabled</Optimization>
       <PreprocessorDefinitions>WIN32;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\..\..\..\BuildTools\headers;..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
       <RuntimeLibrary />
     </ClCompile>
     <Link>
@@ -124,7 +124,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\..\..\..\BuildTools\headers;..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
       <RuntimeLibrary />
     </ClCompile>
     <Link>
@@ -138,7 +138,7 @@
       <WarningLevel>Level3</WarningLevel>
       <PreprocessorDefinitions>WIN32;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <PrecompiledHeader>NotUsing</PrecompiledHeader>
-      <AdditionalIncludeDirectories>..\..\..\..\BuildTools\headers;..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
+      <AdditionalIncludeDirectories>..\..\..\..\CoinUtils\src;..\..\..\..\clp\src;..\..\..\..\osi\src\osi;..\..\..\..\clp\src\osiClp;..\..\..\..\osi\src\osiCpx;..\..\..\..\osi\src\osiVol;..\..\..\..\cbc\src\osiCbc;..\..\..\..\cbc\src;..\..\..\..\cgl\src;..\..\..\..\cgl\src\CglMixedIntegerRounding;..\..\..\..\cgl\src\CglMixedIntegerRounding2;..\..\..\..\cgl\src\CglFlowCover;..\..\..\..\cgl\src\CglClique;..\..\..\..\cgl\src\CglOddHole;..\..\..\..\cgl\src\CglKnapsackCover;..\..\..\..\cgl\src\CglGomory;..\..\..\..\cgl\src\CglDuplicateRow;..\..\..\..\cgl\src\CglProbing;..\..\..\..\cgl\src\CglPreProcess;..\..\..\..\cgl\src\CglTwomir;..\..\..\..\vol\src</AdditionalIncludeDirectories>
       <RuntimeLibrary />
     </ClCompile>
     <Link>

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ init:
         $env:JAVA_HOME = "C:\Program Files\Java\jdk17"
         $env:PATH += ";JAVA_HOME\bin"
       }
-  #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 # scripts that run after cloning repository
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,7 +112,7 @@ before_build:
   - echo Creating %RELEASE_NAME%-src.zip artefact from projects folder
   - call build-third-party-license.bat
   - 7z a -tzip -r -x!.git "c:\projects\sonnet\%RELEASE_NAME%-src.zip" c:\projects\*
-  - echo {"sdk":{"version":"6.0.0","rollForward":"latestMinor"}} > MSVisualStudio\v17\SonnetWrapper\global.json
+  - echo {"sdk":{"version":"6.0.0","rollForward":"latestMinor"}} > global.json
   - nuget restore MSVisualStudio\v17\Sonnet.sln
   - if not "%sonar_token%"=="" ( SonarScanner.MSBuild.exe begin /k:"%RELEASE_NAME%" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.login=%sonar_token%" /o:"jhmgoossens" /d:sonar.c.file.suffixes=- /d:sonar.cpp.file.suffixes=- /d:sonar.objc.file.suffixes=- )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,6 +112,7 @@ before_build:
   - echo Creating %RELEASE_NAME%-src.zip artefact from projects folder
   - call build-third-party-license.bat
   - 7z a -tzip -r -x!.git "c:\projects\sonnet\%RELEASE_NAME%-src.zip" c:\projects\*
+  - choco install dotnet-6.0-sdk
   - nuget restore MSVisualStudio\v17\Sonnet.sln
   - if not "%sonar_token%"=="" ( SonarScanner.MSBuild.exe begin /k:"%RELEASE_NAME%" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.login=%sonar_token%" /o:"jhmgoossens" /d:sonar.c.file.suffixes=- /d:sonar.cpp.file.suffixes=- /d:sonar.objc.file.suffixes=- )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -112,8 +112,7 @@ before_build:
   - echo Creating %RELEASE_NAME%-src.zip artefact from projects folder
   - call build-third-party-license.bat
   - 7z a -tzip -r -x!.git "c:\projects\sonnet\%RELEASE_NAME%-src.zip" c:\projects\*
-  # Add global.json for SonnetWrapper for build error NETSDK1145
-  - echo { "sdk": { "version": "6.0.0", "rollForward": "latestMinor" } } > MSVisualStudio\v17\SonnetWrapper\global.json
+  - echo {"sdk":{"version":"6.0.0","rollForward":"latestMinor"}} > MSVisualStudio\v17\SonnetWrapper\global.json
   - nuget restore MSVisualStudio\v17\Sonnet.sln
   - if not "%sonar_token%"=="" ( SonarScanner.MSBuild.exe begin /k:"%RELEASE_NAME%" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.login=%sonar_token%" /o:"jhmgoossens" /d:sonar.c.file.suffixes=- /d:sonar.cpp.file.suffixes=- /d:sonar.objc.file.suffixes=- )
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -38,7 +38,7 @@ init:
         $env:JAVA_HOME = "C:\Program Files\Java\jdk17"
         $env:PATH += ";JAVA_HOME\bin"
       }
-  - ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
+  #- ps: iex ((new-object net.webclient).DownloadString('https://raw.githubusercontent.com/appveyor/ci/master/scripts/enable-rdp.ps1'))
 
 # scripts that run after cloning repository
 install:
@@ -112,7 +112,8 @@ before_build:
   - echo Creating %RELEASE_NAME%-src.zip artefact from projects folder
   - call build-third-party-license.bat
   - 7z a -tzip -r -x!.git "c:\projects\sonnet\%RELEASE_NAME%-src.zip" c:\projects\*
-  - choco install dotnet-6.0-sdk
+  # Add global.json for SonnetWrapper for build error NETSDK1145
+  - echo { "sdk": { "version": "6.0.0", "rollForward": "latestMinor" } } > MSVisualStudio\v17\SonnetWrapper\global.json
   - nuget restore MSVisualStudio\v17\Sonnet.sln
   - if not "%sonar_token%"=="" ( SonarScanner.MSBuild.exe begin /k:"%RELEASE_NAME%" /d:"sonar.host.url=https://sonarcloud.io" /d:"sonar.login=%sonar_token%" /o:"jhmgoossens" /d:sonar.c.file.suffixes=- /d:sonar.cpp.file.suffixes=- /d:sonar.objc.file.suffixes=- )
 


### PR DESCRIPTION
AppVeyor builds failed with NETSDK1145 error at nuget restore for SonnetWrapper (C++). Resolved by adding global.json mentioning explicitly net6.